### PR TITLE
set day of week to match task page

### DIFF
--- a/frontend/scripts/home_view.js
+++ b/frontend/scripts/home_view.js
@@ -89,7 +89,10 @@ export class HomeView {
             let task_link = document.createElement('a');
             task_link.href = "task.html"
             let button = document.createElement('button');
-            button.classList.add('add-icon')
+            button.classList.add('add-icon');
+            button.addEventListener('click', async () => {
+                sessionStorage.setItem("day-of-week", i);
+            });
             let button_img = document.createElement('img');
             button_img.src = "assets/unripe.png"
             button_img.alt = "Add Task"
@@ -154,4 +157,8 @@ export class HomeView {
         log_out_link.append(log_out_button);
         secondary_div.append(log_out_link);
     }
+}
+
+function setDayOfWeek(i) {
+    
 }

--- a/frontend/scripts/task_view.js
+++ b/frontend/scripts/task_view.js
@@ -95,6 +95,10 @@ export class TaskView {
         for (let i=0; i < 7; i++) {
             let day_option = document.createElement("option");
             day_option.value = i;
+            let selection_option = sessionStorage.getItem("day-of-week");
+            if (selection_option == i) {
+                day_option.selected = "selected";
+            }
             day_option.innerHTML = day_names[i];
             dow_field_dropdown.append(day_option);
         }


### PR DESCRIPTION
Added functionality so that the day of week dropdown on the add task page matches whichever button was clicked on the home page.